### PR TITLE
Initial implementaion of equivalent-domains API support

### DIFF
--- a/lib/bitwarden_ruby.rb
+++ b/lib/bitwarden_ruby.rb
@@ -31,6 +31,7 @@ require "#{APP_ROOT}/lib/db.rb"
 require "#{APP_ROOT}/lib/dbmodel.rb"
 require "#{APP_ROOT}/lib/user.rb"
 require "#{APP_ROOT}/lib/device.rb"
+require "#{APP_ROOT}/lib/domain.rb"
 require "#{APP_ROOT}/lib/cipher.rb"
 require "#{APP_ROOT}/lib/folder.rb"
 

--- a/lib/db.rb
+++ b/lib/db.rb
@@ -93,27 +93,50 @@ class Db
         (version INTEGER)
       ")
 
-      v = @db.execute("SELECT version FROM schema_version").first
-      if !v
-        v = { "version" => 0 }
-      end
+      loop do
+        v = @db.execute("SELECT version FROM schema_version").first
+        if !v
+          v = { "version" => 0 }
+        end
 
-      case v["version"]
-      when 0
-        @db.execute("INSERT INTO schema_version (version) VALUES (1)")
+        case v["version"]
+        when 0
+          @db.execute("INSERT INTO schema_version (version) VALUES (1)")
 
-      when 1
-        @db.execute("
-          CREATE TABLE IF NOT EXISTS
-          folders
-          (uuid STRING PRIMARY KEY,
-          created_at DATETIME,
-          updated_at DATETIME,
-          user_uuid STRING,
-          name BLOB)
-        ")
+        when 1
+          @db.execute("
+            CREATE TABLE IF NOT EXISTS
+            folders
+            (uuid STRING PRIMARY KEY,
+            created_at DATETIME,
+            updated_at DATETIME,
+            user_uuid STRING,
+            name BLOB)
+          ")
 
-        @db.execute("UPDATE schema_version SET version = 2")
+          @db.execute("UPDATE schema_version SET version = 2")
+
+        when 2
+          @db.execute("
+            CREATE TABLE IF NOT EXISTS
+            equiv_domains
+            (uuid STRING PRIMARY KEY,
+            user_uuid STRING)
+          ")
+
+          @db.execute("
+            CREATE TABLE IF NOT EXISTS
+            equiv_domain_names
+            (uuid STRING PRIMARY KEY,
+            domain STRING,
+            domain_uuid STRING)
+          ")
+
+          @db.execute("UPDATE schema_version SET version = 3")
+
+        when 3
+          break
+        end
       end
 
       # eagerly cache column definitions

--- a/lib/domain.rb
+++ b/lib/domain.rb
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2017 joshua stein <jcs@jcs.org>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+class EquivalentDomainName < DBModel
+  set_table_name "equiv_domain_names"
+  set_primary_key "uuid"
+
+  attr_writer :equiv_domain
+
+  def equiv_domain
+    @equiv_domain ||= EquivalentDomain.find_by_uuid(domain_uuid)
+  end
+end
+
+class EquivalentDomain < DBModel
+  set_table_name "equiv_domains"
+  set_primary_key "uuid"
+
+  attr_writer :user
+
+  def to_ary
+    EquivalentDomainName.find_all_by_domain_uuid(uuid).map(&:domain)
+  end
+
+  def user
+    @user ||= User.find_by_uuid(user_uuid)
+  end
+end
+
+def equivalent_domains(user)
+  {
+    "EquivalentDomains" => user.domains.map(&:to_ary),
+    "GlobalEquivalentDomains" => [],
+    "Object" => "domains"
+  }
+end

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -56,6 +56,11 @@ class User < DBModel
       each{|f| f.user = self }
   end
 
+  def domains
+    @domains ||= EquivalentDomain.find_all_by_user_uuid(self.uuid).
+      each{|f| f.user = self }
+  end
+
   def has_password_hash?(hash)
     self.password_hash.timingsafe_equal_to(hash)
   end


### PR DESCRIPTION
Upstream bitwarden supports an API endpoint for retrieving and bulk-updating lists of "equivalent domains": second-level domains and `androidapp://` URIs which are treated as though the are they same name, for the purposes of performing entry lookups.

While all of the clients appear to have support for honoring equivalence, only the web vault has a UI for viewing and updating each collection; thus, this will be a lot more useful once jcs/bitwarden-ruby#14 has been merged.

This PR adds initial support for per-user domain equivalence; global equivalence (with per-user exclusion) wasn't something I needed, so I punted on implementing it, but I don't think it would be too hard to add to this later. This adds two new tables: `equiv_domains` (tying users and collections of domain names together) and `equiv_domain_names` (the domain names themselves).

One unrelated change is that I've added a simple loop to the migrations, to ensure that all migrations get applied when `connect` is called. Otherwise, especially as more migrations get added, it's a pretty good bet that a new installation will wind up missing a few migrations until they've run things a few times.