### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN bundle install
 
 COPY . .
 
-EXPOSE $PORT
+EXPOSE 4567 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.3
+
+ENV RACK_ENV production
+RUN mkdir /app
+WORKDIR /app
+
+COPY Gemfile .
+COPY Gemfile.lock .
+RUN bundle install
+
+COPY . .
+
+EXPOSE $PORT

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ To run the test suite:
 
 	bundle exec rake test
 
+### Docker
+
+To use this with docker we first need to build from the dockerfile
+
+  docker build -t bitwarden-ruby:latest .
+
+Then we can run the docker image
+
+  docker run -p 4567:4567 bitwarden-ruby env RACK_ENV=production bundle exec rackup -p 4567 config.ru 
+
+The dockerfile only runs the ruby application and should be placed behind a reverse proxy container that can serve it via HTTPS for security.
+
 ### 1Password Conversion
 
 Export everything from 1Password in its "1Password Interchange Format".


### PR DESCRIPTION
This adds a lightweight docker implementation that runs the server.
Can be used for integrating with CI, or docker-compose.

The docker image is based on `ruby:2.3` and simply installs the dependencies listed in the Gemfile, and is able to run the server. Doesn't include any SSL by default.

An example docker-compose config that I'm using for my server (includes nginx for reverse proxy and lets encrypt helper for setting up ssl):

```
 nginx-proxy:
    image: jwilder/nginx-proxy
    restart: always
    ports:
      - "80:80"
      - "443:443"
    volumes:
      - "./certs:/etc/nginx/certs:ro"
      - "/etc/nginx/vhost.d"
      - "/usr/share/nginx/html"
      - "/var/run/docker.sock:/tmp/docker.sock:ro"
    labels:
      - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy=true"
  nginx-letsencrypt:
    image: jrcs/letsencrypt-nginx-proxy-companion
    volumes_from: 
      - nginx-proxy 
    volumes:
      - "./certs:/etc/nginx/certs:rw"
      - "/var/run/docker.sock:/var/run/docker.sock:ro"
  bitwarden:
    build: bitwarden-ruby
    command: bundle exec rackup -p 4567 config.ru
    restart: always
    environment:
      - "LETSENCRYPT_EMAIL=${EMAIL}"
      - "LETSENCRYPT_HOST=bitwarden.${DOMAIN}"
      - "VIRTUAL_HOST=bitwarden.${DOMAIN}"
      - "VIRTUAL_PORT=4567"
      - "PORT=4567"
      - "RACK_ENV=production"
      - "ALLOW_SIGNUPS=true"
    volumes:
      - "./bitwarden:/app/db"
```
(see more at https://github.com/jhuizy/server/blob/master/docker-compose.yml).

