### PR TITLE
bitwarden_ruby.rb is now rubywarden.rb

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,6 @@ end
 
 namespace :db do
   task :load_config do
-    require "./lib/bitwarden_ruby.rb"
+    require "./lib/rubywarden.rb"
   end
 end

--- a/tools/1password_import.rb
+++ b/tools/1password_import.rb
@@ -25,7 +25,7 @@
 # bitwarden-ruby installation after creating a new account.
 #
 
-require File.realpath(File.dirname(__FILE__) + "/../lib/bitwarden_ruby.rb")
+require File.realpath(File.dirname(__FILE__) + "/../lib/rubywarden.rb")
 require "getoptlong"
 require 'uri'
 

--- a/tools/activate_totp.rb
+++ b/tools/activate_totp.rb
@@ -22,7 +22,7 @@
 # TOTP secret is saved on the user account.
 #
 
-require File.realpath(File.dirname(__FILE__) + "/../lib/bitwarden_ruby.rb")
+require File.realpath(File.dirname(__FILE__) + "/../lib/rubywarden.rb")
 require "getoptlong"
 require "rotp"
 require "rqrcode"

--- a/tools/bitwarden_import.rb
+++ b/tools/bitwarden_import.rb
@@ -24,7 +24,7 @@
 # bitwarden-ruby installation after creating a new account.
 #
 
-require File.realpath(File.dirname(__FILE__) + '/../lib/bitwarden_ruby.rb')
+require File.realpath(File.dirname(__FILE__) + '/../lib/rubywarden.rb')
 
 require 'csv'
 require 'getoptlong'

--- a/tools/change_master_password.rb
+++ b/tools/change_master_password.rb
@@ -15,7 +15,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-require File.realpath(File.dirname(__FILE__) + "/../lib/bitwarden_ruby.rb")
+require File.realpath(File.dirname(__FILE__) + "/../lib/rubywarden.rb")
 require "getoptlong"
 
 def usage

--- a/tools/keepass_import.rb
+++ b/tools/keepass_import.rb
@@ -26,7 +26,7 @@
 # bitwarden-ruby installation after creating a new account.
 #
 
-require File.realpath(File.dirname(__FILE__) + "/../lib/bitwarden_ruby.rb")
+require File.realpath(File.dirname(__FILE__) + "/../lib/rubywarden.rb")
 require "getoptlong"
 require "rubeepass"
 
@@ -141,7 +141,7 @@ def getEntries(db)
       cdata['Notes'] = encrypt(entry[1].notes) if entry[1].notes.present?
 
       if entry[1].attachments.any?
-        puts "This entry has an attachment - but it won't be converted as bitwarden_ruby does not support attachments yet."
+        puts "This entry has an attachment - but it won't be converted as rubywarden does not support attachments yet."
       end
 
       c.data = cdata.to_json

--- a/tools/lastpass_import.rb
+++ b/tools/lastpass_import.rb
@@ -26,7 +26,7 @@
 # bitwarden-ruby installation after creating a new account.
 #
 
-require File.realpath(File.dirname(__FILE__) + "/../lib/bitwarden_ruby.rb")
+require File.realpath(File.dirname(__FILE__) + "/../lib/rubywarden.rb")
 require "getoptlong"
 require "csv"
 

--- a/tools/migrate_to_ar.rb
+++ b/tools/migrate_to_ar.rb
@@ -31,7 +31,7 @@ usage unless environment
 
 require 'yaml_db'
 require 'fileutils'
-require File.realpath(File.dirname(__FILE__) + "/../lib/bitwarden_ruby.rb")
+require File.realpath(File.dirname(__FILE__) + "/../lib/rubywarden.rb")
 ActiveRecord::Base.remove_connection
 
 data_file = "db/dump.yml"


### PR DESCRIPTION
After the project rename, a few trailing references to the old `bitwarden_ruby.rb` stuck around. This corrects those.