### PR TITLE
Gemfile: Ruby: Update gemfile to allow newer ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby ">= 2.2.8", "< 2.5.0"
+ruby ">= 2.2.8", "< 2.5.2"
 
 gem "sinatra", "~> 2.0.3"
 gem "sinatra-contrib", "~> 2.0.3"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby ">= 2.2.8", "< 2.5.2"
+ruby ">= 2.2.8"
 
 gem "sinatra", "~> 2.0.3"
 gem "sinatra-contrib", "~> 2.0.3"


### PR DESCRIPTION
Ubuntu 18.04 package manager will install latest ruby
Current version supplied is Ruby 2.5.1p57 (2018-3-29 revision 63029)
Currently the gemfile prohibits using this version.
I have experienced no real issues with it..