### PR TITLE
Adding support for attachments

### DIFF
--- a/API.md
+++ b/API.md
@@ -592,6 +592,62 @@ Send an empty `DELETE` request to `$baseURL/ciphers/(cipher UUID)`:
 
 A successful but zero-length response will be returned.
 
+### Adding an attachment
+
+Send a `POST` request to `$baseURL/ciphers/(cipher UUID)/attachment`
+
+It is a multipart/form-data post, with the file under the `data`-attribute the single posted entity.
+
+
+	POST $baseURL/ciphers/(cipher UUID)/attachment
+	Content-type: application/json
+	Authorization: Bearer $access_token
+	{
+		"data": {
+			"filename": "encrypted_filename"
+			"tempfile": blob
+		}
+	}
+
+The JSON response will then be the complete cipher item, but now containing an entry for the new attachment:
+
+	{
+		"FolderId"=>nil,
+		...
+		"Data"=> ...,
+		"Attachments"=>
+		[
+			{	"Id"=>"7xytytjp1hc2ijy3n5y5vbbnzcukmo8b",
+					"Url"=> "https://cdn.bitwarden.com/attachments/(cipher UUID)/7xytytjp1hc2ijy3n5y5vbbnzcukmo8b",
+					"FileName"=> "2.GOkRA8iZio1KxB+UkJpfcA==|/Mc8ACbPr9CRRQmNKPYHVg==|4BBQf8YTbPupap6qR97qMdn0NJ88GdTgDPIyBsQ46aA=",
+					"Size"=>"65",
+					"SizeName"=>"65 Bytes",
+					"Object"=>"attachment"
+				}
+			],
+		...,
+		"Object"=>"cipher"
+	}
+
+### Deleting an attachment
+
+Send an empty `DELETE` request to `$baseURL/ciphers/(cipher UUID)/attachment/(attachment id)`:
+
+	DELETE $baseURL/ciphers/(cipher UUID)/attachment/(attachment id)
+	Authorization: Bearer (access_token)
+
+A successful but zero-length response will be returned.
+
+### Downloading an attachment
+
+$cdn_url using the official server is https://cdn.bitwarden.com.
+
+Send an unauthenticated `GET` request to `$cdn_url/attachments/(cipher UUID)/(attachment id)`:
+
+	GET $cdn_url/attachments/(cipher UUID)/(attachment id)
+
+The file will be sent as a response.
+
 ### Folders
 
 To create a folder, `POST` to `$baseURL/folders`:

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,15 @@
-require "rake/testtask"
-
 # rake db:create_migration NAME=...
 require "sinatra/activerecord/rake"
-
-Rake::TestTask.new do |t|
-  t.pattern = "spec/*_spec.rb"
-end
 
 namespace :db do
   task :load_config do
     require "./lib/rubywarden.rb"
   end
+end
+
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << "spec"
+  t.pattern = "spec/*_spec.rb"
 end

--- a/db/migrate/20180818095054_create_attachments.rb
+++ b/db/migrate/20180818095054_create_attachments.rb
@@ -1,0 +1,15 @@
+class CreateAttachments < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :ciphers, :attachments
+    create_table :attachments, id: :string, primary_key: :uuid do |t|
+      t.string :cipher_uuid
+      t.string :url
+      t.string :filename
+      t.integer :size
+      t.binary :file
+      t.timestamps
+    end
+    add_foreign_key :attachments, :ciphers, { column: :cipher_uuid, primary_key: :uuid }
+    add_index(:attachments, :cipher_uuid)
+  end
+end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -18,10 +18,12 @@ require 'sinatra/activerecord'
 require 'sinatra/namespace'
 
 require_relative 'helpers/request_helpers'
+require_relative 'helpers/attachment_helpers'
 
 require_relative 'routes/api'
 require_relative 'routes/icons'
 require_relative 'routes/identity'
+require_relative 'routes/attachments'
 
 module Rubywarden
   class App < Sinatra::Base
@@ -36,6 +38,7 @@ module Rubywarden
     end
 
     helpers Rubywarden::RequestHelpers
+    helpers Rubywarden::AttachmentHelpers
 
     before do
       if request.content_type.to_s.match(/\Aapplication\/json(;|\z)/)
@@ -58,5 +61,6 @@ module Rubywarden
     register Rubywarden::Routing::Api
     register Rubywarden::Routing::Icons
     register Rubywarden::Routing::Identity
+    register Rubywarden::Routing::Attachments
   end
 end

--- a/lib/attachment.rb
+++ b/lib/attachment.rb
@@ -24,7 +24,9 @@ class Attachment < DBModel
   belongs_to :cipher, foreign_key: :cipher_uuid, inverse_of: :attachments
 
   def self.build_from_params(params, context)
-    attachment = new params
+    attachment = new filename: params[:filename],
+                     size: params[:size],
+                     file: params[:file]
     attachment.context = context
     attachment
   end

--- a/lib/attachment.rb
+++ b/lib/attachment.rb
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2017 joshua stein <jcs@jcs.org>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+class Attachment < DBModel
+  self.table_name = "attachments"
+  attr_accessor :context
+
+  before_create :generate_uuid_primary_key
+  before_create :generate_url
+
+  belongs_to :cipher, foreign_key: :cipher_uuid, inverse_of: :attachments
+
+  def self.build_from_params(params, context)
+    attachment = new params
+    attachment.context = context
+    attachment
+  end
+
+  def to_hash
+    {
+      "Id" => self.uuid,
+      "Url" => self.url,
+      "FileName" => self.filename.to_s,
+      "Size" => self.size,
+      "SizeName" => human_file_size,
+      "Object" => "attachment"
+    }
+  end
+
+  private
+
+  def generate_url
+    self.url = context.url("/attachments/#{self.cipher_uuid}/#{self.id}")
+  end
+
+  def human_file_size
+    ActiveSupport::NumberHelper.number_to_human_size(self.size)
+  end
+end

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -136,4 +136,16 @@ class Cipher < DBModel
       self.identity = params[:identity].ucfirst_hash
     end
   end
+
+  def add_attachment attachment:
+    target = self.attachments.nil? ? [] : self.attachments
+    target << attachment
+    self.attachments = target
+  end
+
+  def remove_attachment attachment_id:
+    target = self.attachments.nil? ? [] : self.attachments
+    removed = target.reject {|attachment| attachment["Id"] == attachment_id }
+    self.attachments = removed
+  end
 end

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -22,13 +22,13 @@ class Cipher < DBModel
 
   belongs_to :user, foreign_key: :user_uuid, inverse_of: :folders
   belongs_to :folder, foreign_key: :folder_uuid, inverse_of: :ciphers, optional: true
+  has_many :attachments, foreign_key: :cipher_uuid, dependent: :destroy
 
   serialize :fields, JSON
   serialize :login, JSON
   serialize :securenote, JSON
   serialize :card, JSON
   serialize :identity, JSON
-  serialize :attachments, JSON
 
   TYPE_LOGIN    = 1
   TYPE_NOTE     = 2
@@ -89,7 +89,7 @@ class Cipher < DBModel
       "FolderId" => self.folder_uuid,
       "Favorite" => self.favorite,
       "OrganizationId" => nil,
-      "Attachments" => self.attachments,
+      "Attachments" => self.attachments.map(&:to_hash),
       "OrganizationUseTotp" => false,
       "Object" => "cipher",
       "Name" => self.name,
@@ -135,17 +135,5 @@ class Cipher < DBModel
     when TYPE_IDENTITY
       self.identity = params[:identity].ucfirst_hash
     end
-  end
-
-  def add_attachment attachment:
-    target = self.attachments.nil? ? [] : self.attachments
-    target << attachment
-    self.attachments = target
-  end
-
-  def remove_attachment attachment_id:
-    target = self.attachments.nil? ? [] : self.attachments
-    removed = target.reject {|attachment| attachment["Id"] == attachment_id }
-    self.attachments = removed
   end
 end

--- a/lib/helpers/attachment_helpers.rb
+++ b/lib/helpers/attachment_helpers.rb
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2018 joshua stein <jcs@jcs.org>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+module Rubywarden
+  module AttachmentHelpers
+    def attachment_url(uuid:, id:)
+      url("/attachments/#{uuid}/#{id}")
+    end
+
+    def attachment_path(id:, uuid:, app:)
+      base = File.expand_path("data/attachments/#{uuid}/", app.root)
+      FileUtils.mkpath(base)
+      File.expand_path(id, base)
+    end
+
+    def retrieve_cipher(uuid: )
+      d = device_from_bearer
+      if !d
+        halt validation_error("invalid bearer")
+      end
+
+      c = nil
+      if params[:uuid].blank? ||
+      !(c = Cipher.find_by_user_uuid_and_uuid(d.user_uuid, params[:uuid]))
+        halt validation_error("invalid cipher")
+      end
+      return c
+    end
+
+    def delete_attachment uuid:, attachment_id:, app:
+      cipher = retrieve_cipher uuid: uuid
+      unless attachment_id =~ /\A[0-9a-f]{32}\z/
+        return validation_error("invalid attachment id")
+      end
+      cipher.remove_attachment attachment_id: attachment_id
+      path = attachment_path(id: attachment_id, uuid: uuid, app: app)
+      Cipher.transaction do
+        if !cipher.save
+          return validation_error("error saving")
+        end
+        File.delete path if File.exist? path
+
+        ""
+      end
+    end
+
+    def human_file_size(byte_size:)
+      ActiveSupport::NumberHelper.number_to_human_size(byte_size)
+      #Filesize.from("#{byte_size} b").pretty
+    end
+  end
+end

--- a/lib/helpers/attachment_helpers.rb
+++ b/lib/helpers/attachment_helpers.rb
@@ -16,16 +16,6 @@
 
 module Rubywarden
   module AttachmentHelpers
-    def attachment_url(uuid:, id:)
-      url("/attachments/#{uuid}/#{id}")
-    end
-
-    def attachment_path(id:, uuid:, app:)
-      base = File.expand_path("data/attachments/#{uuid}/", app.root)
-      FileUtils.mkpath(base)
-      File.expand_path(id, base)
-    end
-
     def retrieve_cipher(uuid: )
       d = device_from_bearer
       if !d
@@ -33,33 +23,16 @@ module Rubywarden
       end
 
       c = nil
-      if params[:uuid].blank? ||
-      !(c = Cipher.find_by_user_uuid_and_uuid(d.user_uuid, params[:uuid]))
+      if uuid.blank? || !(c = Cipher.find_by_user_uuid_and_uuid(d.user_uuid, uuid))
         halt validation_error("invalid cipher")
       end
       return c
     end
 
-    def delete_attachment uuid:, attachment_id:, app:
+    def delete_attachment uuid:, attachment_uuid:
       cipher = retrieve_cipher uuid: uuid
-      unless attachment_id =~ /\A[0-9a-f]{32}\z/
-        return validation_error("invalid attachment id")
-      end
-      cipher.remove_attachment attachment_id: attachment_id
-      path = attachment_path(id: attachment_id, uuid: uuid, app: app)
-      Cipher.transaction do
-        if !cipher.save
-          return validation_error("error saving")
-        end
-        File.delete path if File.exist? path
-
-        ""
-      end
-    end
-
-    def human_file_size(byte_size:)
-      ActiveSupport::NumberHelper.number_to_human_size(byte_size)
-      #Filesize.from("#{byte_size} b").pretty
+      cipher.attachments.find(attachment_uuid).destroy
+      ""
     end
   end
 end

--- a/lib/helpers/request_helpers.rb
+++ b/lib/helpers/request_helpers.rb
@@ -56,8 +56,6 @@ module Rubywarden
       if uuid.blank? || !(c = Cipher.find_by_user_uuid_and_uuid(d.user_uuid, uuid))
         halt validation_error("invalid cipher")
       end
-
-      FileUtils.rm_r attachment_path(id: "", uuid: c.uuid, app: app) if Dir.exist?(attachment_path(id: "", uuid: c.uuid, app: app))
       c.destroy
       ""
     end # delete_cipher

--- a/lib/helpers/request_helpers.rb
+++ b/lib/helpers/request_helpers.rb
@@ -45,5 +45,21 @@ module Rubywarden
         "Object" => "error",
       }.to_json ]
     end
+
+    def delete_cipher app:, uuid:
+      d = device_from_bearer
+      if !d
+        halt validation_error("invalid bearer")
+      end
+
+      c = nil
+      if uuid.blank? || !(c = Cipher.find_by_user_uuid_and_uuid(d.user_uuid, uuid))
+        halt validation_error("invalid cipher")
+      end
+
+      FileUtils.rm_r attachment_path(id: "", uuid: c.uuid, app: app) if Dir.exist?(attachment_path(id: "", uuid: c.uuid, app: app))
+      c.destroy
+      ""
+    end # delete_cipher
   end
 end

--- a/lib/routes/api.rb
+++ b/lib/routes/api.rb
@@ -209,20 +209,7 @@ module Rubywarden
 
           # delete a cipher
           delete "/ciphers/:uuid" do
-            d = device_from_bearer
-            if !d
-              return validation_error("invalid bearer")
-            end
-
-            c = nil
-            if params[:uuid].blank? ||
-            !(c = Cipher.find_by_user_uuid_and_uuid(d.user_uuid, params[:uuid]))
-              return validation_error("invalid cipher")
-            end
-
-            c.destroy
-
-            ""
+            delete_cipher app: app, uuid: params[:uuid]
           end
 
           #

--- a/lib/routes/attachments.rb
+++ b/lib/routes/attachments.rb
@@ -37,7 +37,7 @@ module Rubywarden
             file = params[:data][:tempfile]
             attachment_params = { filename: filename,
                                   size: file.size,
-                                  file: file }
+                                  file: file.read }
             attachment = cipher.attachments.build_from_params(attachment_params, self)
 
             Attachment.transaction do

--- a/lib/routes/attachments.rb
+++ b/lib/routes/attachments.rb
@@ -35,26 +35,13 @@ module Rubywarden
             end
 
             file = params[:data][:tempfile]
-            # https://github.com/bitwarden/core/blob/master/src/Core/Services/Implementations/CipherService.cs#L148
-            #   var attachmentId = Utilities.CoreHelpers.SecureRandomString(32, upper: false, special: false);
-            # use hex string, to make validation simpler for get case
-            id = SecureRandom.hex(32)[0,32]
+            attachment_params = { filename: filename,
+                                  size: file.size,
+                                  file: file }
+            attachment = cipher.attachments.build_from_params(attachment_params, self)
 
-            File.open attachment_path(id: id, uuid: params[:uuid], app: app), 'wb' do |f|
-              f.write(file.read)
-            end
-
-            cipher.add_attachment attachment: {
-              Id: id,
-              Url: attachment_url(uuid: params[:uuid], id: id),
-              FileName: filename,
-              Size: file.size,
-              SizeName: human_file_size(byte_size: file.size),
-              Object: "attachment"
-            }
-
-            Cipher.transaction do
-              if !cipher.save
+            Attachment.transaction do
+              if !attachment.save
                 return validation_error("error saving")
               end
 
@@ -63,28 +50,18 @@ module Rubywarden
           end
 
           delete "/ciphers/:uuid/attachment/:attachment_id" do
-            delete_attachment uuid: params[:uuid], attachment_id: params[:attachment_id], app: app
+            delete_attachment uuid: params[:uuid], attachment_uuid: params[:attachment_id]
           end
 
           post "/ciphers/:uuid/attachment/:attachment_id/delete" do
-            delete_attachment uuid: params[:uuid], attachment_id: params[:attachment_id], app: app
+            delete_attachment uuid: params[:uuid], attachment_uuid: params[:attachment_id]
           end
         end # BASE_URL
 
         app.get "/attachments/:uuid/:attachment_id" do
-          unless params[:uuid] =~ /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
-            return validation_error("invalid uuid")
-          end
-          unless params[:attachment_id] =~ /\A[0-9a-f]{32}\z/
-            return validation_error("invalid attachment id")
-          end
-          path = attachment_path(id: params[:attachment_id], uuid: params[:uuid], app: app)
-
-          if File.exist? path
-            send_file path
-          else
-            halt 404
-          end
+          a = Attachment.find_by_uuid_and_cipher_uuid(params[:attachment_id], params[:uuid])
+          attachment(a.filename)
+          response.write(a.file)
         end
       end # registered app
     end

--- a/lib/routes/attachments.rb
+++ b/lib/routes/attachments.rb
@@ -1,0 +1,92 @@
+#
+# Copyright (c) 2018 joshua stein <jcs@jcs.org>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+# uses helpers/attachment_helpers
+module Rubywarden
+  module Routing
+    module Attachments
+      def self.registered(app)
+        app.namespace BASE_URL do
+          post "/ciphers/:uuid/attachment" do
+            cipher = retrieve_cipher uuid: params[:uuid]
+
+            need_params(:data) do |p|
+              return validation_error("#{p} cannot be blank")
+            end
+
+            # we have to extract filename from data -> head, since data -> filename is truncated
+            filename = nil
+            if md = params[:data][:head].match(/filename=\"(\S+)\"\r\nContent-Type/)
+              filename = md[1]
+            else
+              return validation_error("filename cannot be blank")
+            end
+
+            file = params[:data][:tempfile]
+            # https://github.com/bitwarden/core/blob/master/src/Core/Services/Implementations/CipherService.cs#L148
+            #   var attachmentId = Utilities.CoreHelpers.SecureRandomString(32, upper: false, special: false);
+            # use hex string, to make validation simpler for get case
+            id = SecureRandom.hex(32)[0,32]
+
+            File.open attachment_path(id: id, uuid: params[:uuid], app: app), 'wb' do |f|
+              f.write(file.read)
+            end
+
+            cipher.add_attachment attachment: {
+              Id: id,
+              Url: attachment_url(uuid: params[:uuid], id: id),
+              FileName: filename,
+              Size: file.size,
+              SizeName: human_file_size(byte_size: file.size),
+              Object: "attachment"
+            }
+
+            Cipher.transaction do
+              if !cipher.save
+                return validation_error("error saving")
+              end
+
+              cipher.to_hash.to_json
+            end
+          end
+
+          delete "/ciphers/:uuid/attachment/:attachment_id" do
+            delete_attachment uuid: params[:uuid], attachment_id: params[:attachment_id], app: app
+          end
+
+          post "/ciphers/:uuid/attachment/:attachment_id/delete" do
+            delete_attachment uuid: params[:uuid], attachment_id: params[:attachment_id], app: app
+          end
+        end # BASE_URL
+
+        app.get "/attachments/:uuid/:attachment_id" do
+          unless params[:uuid] =~ /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
+            return validation_error("invalid uuid")
+          end
+          unless params[:attachment_id] =~ /\A[0-9a-f]{32}\z/
+            return validation_error("invalid attachment id")
+          end
+          path = attachment_path(id: params[:attachment_id], uuid: params[:uuid], app: app)
+
+          if File.exist? path
+            send_file path
+          else
+            halt 404
+          end
+        end
+      end # registered app
+    end
+  end
+end

--- a/lib/rubywarden.rb
+++ b/lib/rubywarden.rb
@@ -36,6 +36,7 @@ require "#{APP_ROOT}/lib/user.rb"
 require "#{APP_ROOT}/lib/device.rb"
 require "#{APP_ROOT}/lib/cipher.rb"
 require "#{APP_ROOT}/lib/folder.rb"
+require "#{APP_ROOT}/lib/attachment.rb"
 
 BASE_URL ||= "/api"
 IDENTITY_BASE_URL ||= "/identity"

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -1,0 +1,107 @@
+require "spec_helper.rb"
+
+@access_token = nil
+@cipher_uuid = nil
+@cipher = nil
+
+describe "attachment module" do
+  before do
+    FileUtils.rm_r "tmp/spec" if Dir.exist?("tmp/spec")
+    FileUtils.mkpath "tmp/spec"
+    app.set :root, "tmp/spec"
+
+    post "/api/accounts/register", {
+      :name => nil,
+      :email => "api@example.com",
+      :masterPasswordHash => Bitwarden.hashPassword("asdf", "api@example.com"),
+      :masterPasswordHint => nil,
+      :key => Bitwarden.makeEncKey(
+        Bitwarden.makeKey("adsf", "api@example.com")
+      ),
+    }
+
+    post "/identity/connect/token", {
+      :grant_type => "password",
+      :username => "api@example.com",
+      :password => Bitwarden.hashPassword("asdf", "api@example.com"),
+      :scope => "api offline_access",
+      :client_id => "browser",
+      :deviceType => 3,
+      :deviceIdentifier => SecureRandom.uuid,
+      :deviceName => "firefox",
+      :devicePushToken => ""
+    }
+
+    @access_token = last_json_response["access_token"]
+
+    post_json "/api/ciphers", {
+      :type => 1,
+      :folderId => nil,
+      :organizationId => nil,
+      :name => "2.d7MttWzJTSSKx1qXjHUxlQ==|01Ath5UqFZHk7csk5DVtkQ==|EMLoLREgCUP5Cu4HqIhcLqhiZHn+NsUDp8dAg1Xu0Io=",
+      :notes => nil,
+      :favorite => false,
+      :login => {
+        :uri => "2.T57BwAuV8ubIn/sZPbQC+A==|EhUSSpJWSzSYOdJ/AQzfXuUXxwzcs/6C4tOXqhWAqcM=|OWV2VIqLfoWPs9DiouXGUOtTEkVeklbtJQHkQFIXkC8=",
+        :username => "2.JbFkAEZPnuMm70cdP44wtA==|fsN6nbT+udGmOWv8K4otgw==|JbtwmNQa7/48KszT2hAdxpmJ6DRPZst0EDEZx5GzesI=",
+        :password => "2.e83hIsk6IRevSr/H1lvZhg==|48KNkSCoTacopXRmIZsbWg==|CIcWgNbaIN2ix2Fx1Gar6rWQeVeboehp4bioAwngr0o=",
+        :totp => nil
+      }
+    }, {
+      "HTTP_AUTHORIZATION" => "Bearer #{@access_token}",
+    }
+    @cipher_uuid = last_json_response["Id"]
+    @cipher = Cipher.find_by_uuid(@cipher_uuid)
+  end
+
+
+  it "does not allow access with bogus bearer token" do
+    post_json "/api/ciphers/#{@cipher_uuid}/attachment", {
+      data: ""
+    }, {
+      "HTTP_AUTHORIZATION" => "Bearer #{@access_token.upcase}",
+    }
+
+    last_response.status.wont_equal 200
+  end
+
+  it "allows creating, downloading and deleting an attachment" do
+    post "/api/ciphers/#{@cipher_uuid}/attachment", {
+      data: Rack::Test::UploadedFile.new(StringIO.new("dummy"), original_filename: "test")
+    }, {
+      "HTTP_AUTHORIZATION" => "Bearer #{@access_token}"
+    }
+    last_response.status.must_equal 200
+    Dir.glob("tmp/spec/data/attachments/#{@cipher_uuid}/*").wont_be_empty
+
+    attachment = last_json_response["Attachments"].first
+
+    # downloading
+    get attachment["Url"]
+    last_response.status.must_equal 200
+
+    # deleting
+    delete_json "/api/ciphers/#{@cipher_uuid}/attachment/#{attachment["Id"]}", {}, {
+      "HTTP_AUTHORIZATION" => "Bearer #{@access_token}",
+    }
+
+    last_response.status.must_equal 200
+    Cipher.find_by_uuid(@cipher_uuid).attachments.must_be_empty
+    Dir.glob("tmp/spec/data/attachments/#{@cipher_uuid}/*").must_be_empty
+  end
+
+  it "deletes attachments when cipher is deleted" do
+    post "/api/ciphers/#{@cipher_uuid}/attachment", {
+      data: Rack::Test::UploadedFile.new(StringIO.new("dummy"), original_filename: "test")
+    }, {
+      "HTTP_AUTHORIZATION" => "Bearer #{@access_token}"
+    }
+    last_response.status.must_equal 200
+    delete_json "/api/ciphers/#{@cipher_uuid}", {}, {
+      "HTTP_AUTHORIZATION" => "Bearer #{@access_token}",
+    }
+
+    Cipher.find_by_uuid(@cipher_uuid).must_be_nil
+    Dir.exist?("tmp/spec/data/attachments/#{@cipher_uuid}").wont_equal true
+  end
+end

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -72,8 +72,6 @@ describe "attachment module" do
       "HTTP_AUTHORIZATION" => "Bearer #{@access_token}"
     }
     last_response.status.must_equal 200
-    Dir.glob("tmp/spec/data/attachments/#{@cipher_uuid}/*").wont_be_empty
-
     attachment = last_json_response["Attachments"].first
 
     # downloading
@@ -102,6 +100,6 @@ describe "attachment module" do
     }
 
     Cipher.find_by_uuid(@cipher_uuid).must_be_nil
-    Dir.exist?("tmp/spec/data/attachments/#{@cipher_uuid}").wont_equal true
+    Attachment.where(cipher_uuid: @cipher_uuid).must_be_empty
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,11 +3,6 @@ ENV["RACK_ENV"] = "test"
 require "minitest/autorun"
 require "rack/test"
 
-# clear out test db
-if File.exist?(f = File.dirname(__FILE__) + "/../db/test.sqlite3")
-  File.unlink(f)
-end
-
 # most tests require this to be on
 ALLOW_SIGNUPS = true
 


### PR DESCRIPTION
This branch adds support for attachments:
 * relevant api methods have been documented in API.md
 * Files are stored as received under their uuid in ```data/attachments/cipher-uuid/uuid```. 
 * There are some basic specs regarding the basic crud operations on attachments. 
 * Currently the models only takes care of the information saved in the database, and the controller/route handles the storage and deletion of files from the filesystem
 * Controller is in ```lib/routes/attachment.rb``` and it uses some methods from ```lib/helpers/attachment_helpers.rb```
 * deleting a cipher has been extending to also clean up attachments