### PR TITLE
Add optional jwt key location override

### DIFF
--- a/lib/bitwarden.rb
+++ b/lib/bitwarden.rb
@@ -17,6 +17,7 @@
 require "jwt"
 require "pbkdf2"
 require "openssl"
+require "yaml"
 
 class Bitwarden
   class InvalidCipherString < StandardError; end
@@ -203,7 +204,8 @@ class Bitwarden
 
   class Token
     class << self
-      KEY = "#{APP_ROOT}/db/#{RACK_ENV}/jwt-rsa.key"
+      dbconfig = YAML.load(File.read('db/config.yml'))
+      KEY = dbconfig[RACK_ENV]['key'] || "#{APP_ROOT}/db/#{RACK_ENV}/jwt-rsa.key"
 
       attr_reader :rsa
 


### PR DESCRIPTION
I'm not a ruby developer, so this may not be the best way to handle this. Its just a POC.

I would like to keep my DB and KEY in my syncthing folder. This is easy for the database. The KEY path is partially hard coded for the `db/<environment>` directory. This change allows you to override it in the `db/config.yml` file with a `key: /location/to/key` parameter.

If there is already a better way to handle this, please let me know. Thanks