### PR TITLE
add extra attribute support to keepass importer

### DIFF
--- a/tools/keepass_import.rb
+++ b/tools/keepass_import.rb
@@ -146,6 +146,17 @@ def getEntries(db)
         puts "This entry has an attachment - but it won't be converted as rubywarden does not support attachments yet."
       end
 
+      if entry[1].additional_attributes.any?
+        cdata['Fields'] = []
+        entry[1].additional_attributes.each_pair do |k, v|
+          cdata['Fields'].push(
+            'Type' => 0, # 0 = text, 1 = hidden, 2 = boolean
+            'Name' => encrypt(k),
+            'Value' => encrypt(v)
+          )
+        end
+      end
+
       c.data = cdata.to_json
 
       @to_save[c.type] ||= []


### PR DESCRIPTION
Using this patch, I was able to import 150 records where ~20 of them had additional attributes.  "hidden" are supported by some keepass programs but not all, I don't *think* it's a standard feature to rely on, and `rubeepass` doesn't have any concept of it - so I just saved all of the attributes as "text" (non-hidden).