### PR TITLE
Spec Helpers: Modularization + "Factory"

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -30,7 +30,7 @@ module Rubywarden
     register Sinatra::Namespace
     register Sinatra::ActiveRecordExtension
 
-    set :root, File.dirname(__FILE__)
+    set :root, File.expand_path("..", File.dirname(__FILE__))
 
     configure do
       enable :logging

--- a/spec/attachment_spec.rb
+++ b/spec/attachment_spec.rb
@@ -8,39 +8,8 @@ describe "attachment module" do
   before do
     User.all.delete_all
 
-    post "/api/accounts/register", {
-      :name => nil,
-      :email => "api@example.com",
-      :masterPasswordHash => Bitwarden.hashPassword("asdf", "api@example.com",
-        User::DEFAULT_KDF_TYPE,
-        Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
-      :masterPasswordHint => nil,
-      :key => Bitwarden.makeEncKey(
-        Bitwarden.makeKey("adsf", "api@example.com",
-        User::DEFAULT_KDF_TYPE,
-        Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
-      ),
-      :kdf => Bitwarden::KDF::TYPE_IDS[User::DEFAULT_KDF_TYPE],
-      :kdfIterations => Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE],
-    }
-    last_response.status.must_equal 200
-
-    post "/identity/connect/token", {
-      :grant_type => "password",
-      :username => "api@example.com",
-      :password => Bitwarden.hashPassword("asdf", "api@example.com",
-        User::DEFAULT_KDF_TYPE,
-        Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
-      :scope => "api offline_access",
-      :client_id => "browser",
-      :deviceType => 3,
-      :deviceIdentifier => SecureRandom.uuid,
-      :deviceName => "firefox",
-      :devicePushToken => ""
-    }
-    last_response.status.must_equal 200
-
-    @access_token = last_json_response["access_token"]
+    Rubywarden::Test::Factory.create_user
+    @access_token = Rubywarden::Test::Factory.login_user
 
     post_json "/api/ciphers", {
       :type => 1,

--- a/spec/bitwarden_importer_spec.rb
+++ b/spec/bitwarden_importer_spec.rb
@@ -10,21 +10,7 @@ describe "bitwarden importer" do
     @master_key = Bitwarden.makeKey(@password, @email,
       User::DEFAULT_KDF_TYPE,
       Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE])
-
-    post "/api/accounts/register", {
-      :name => nil,
-      :email => @email,
-      :masterPasswordHash => Bitwarden.hashPassword(@password, @email,
-        User::DEFAULT_KDF_TYPE,
-        Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
-      :masterPasswordHint => nil,
-      :key => Bitwarden.makeEncKey(@master_key),
-      :kdf => Bitwarden::KDF::TYPE_IDS[User::DEFAULT_KDF_TYPE],
-      :kdfIterations => Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE],
-    }
-    last_response.status.must_equal 200
-
-    @user = User.where(:email => @email).first!
+    @user = Rubywarden::Test::Factory.create_user email: @email, password: @password
   end
 
   it "imports all expected data" do

--- a/spec/cipher_spec.rb
+++ b/spec/cipher_spec.rb
@@ -6,39 +6,8 @@ describe "cipher module" do
   before do
     User.all.delete_all
 
-    post "/api/accounts/register", {
-      :name => nil,
-      :email => "api@example.com",
-      :masterPasswordHash => Bitwarden.hashPassword("asdf", "api@example.com",
-        User::DEFAULT_KDF_TYPE,
-        Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
-      :masterPasswordHint => nil,
-      :key => Bitwarden.makeEncKey(
-        Bitwarden.makeKey("adsf", "api@example.com",
-        User::DEFAULT_KDF_TYPE,
-        Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
-      ),
-      :kdf => Bitwarden::KDF::TYPE_IDS[User::DEFAULT_KDF_TYPE],
-      :kdfIterations => Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE],
-    }
-    last_response.status.must_equal 200
-
-    post "/identity/connect/token", {
-      :grant_type => "password",
-      :username => "api@example.com",
-      :password => Bitwarden.hashPassword("asdf", "api@example.com",
-        User::DEFAULT_KDF_TYPE,
-        Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
-      :scope => "api offline_access",
-      :client_id => "browser",
-      :deviceType => 3,
-      :deviceIdentifier => SecureRandom.uuid,
-      :deviceName => "firefox",
-      :devicePushToken => ""
-    }
-    last_response.status.must_equal 200
-
-    @access_token = last_json_response["access_token"]
+    Rubywarden::Test::Factory.create_user
+    @access_token = Rubywarden::Test::Factory.login_user
   end
 
   it "should not allow access with bogus bearer token" do

--- a/spec/folder_spec.rb
+++ b/spec/folder_spec.rb
@@ -6,42 +6,8 @@ describe "folder module" do
   before do
     User.all.delete_all
 
-    post "/api/accounts/register", {
-      :name => nil,
-      :email => "api@example.com",
-      :masterPasswordHash => Bitwarden.hashPassword("asdf", "api@example.com",
-        User::DEFAULT_KDF_TYPE,
-        Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
-      :masterPasswordHint => nil,
-      :key => Bitwarden.makeEncKey(
-        Bitwarden.makeKey("adsf", "api@example.com", User::DEFAULT_KDF_TYPE,
-        Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
-      ),
-      :kdf => Bitwarden::KDF::TYPE_IDS[User::DEFAULT_KDF_TYPE],
-      :kdfIterations => Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE],
-    }
-    if last_response.status != 200
-      raise last_response.inspect
-    end
-
-    post "/identity/connect/token", {
-      :grant_type => "password",
-      :username => "api@example.com",
-      :password => Bitwarden.hashPassword("asdf", "api@example.com",
-        User::DEFAULT_KDF_TYPE,
-        Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
-      :scope => "api offline_access",
-      :client_id => "browser",
-      :deviceType => 3,
-      :deviceIdentifier => SecureRandom.uuid,
-      :deviceName => "firefox",
-      :devicePushToken => ""
-    }
-    if last_response.status != 200
-      raise last_response.inspect
-    end
-
-    @access_token = last_json_response["access_token"]
+    Rubywarden::Test::Factory.create_user
+    @access_token = Rubywarden::Test::Factory.login_user
   end
 
   it "should not allow access with bogus bearer token" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,36 +18,15 @@ ActiveRecord::Migration.verbose = false
 ActiveRecord::Migrator.up "db/migrate"
 
 # in case migrations changed what we're testing
-[ User, Cipher, Device, Folder ].each do |c|
+[ Attachment, User, Cipher, Device, Folder ].each do |c|
   c.send(:reset_column_information)
 end
 
 include Rack::Test::Methods
 
-def last_json_response
-  JSON.parse(last_response.body)
-end
+Dir[Rubywarden::App.settings.root + '/spec/support/**/*.rb'].sort.each { |f| require f }
+include Rubywarden::Test::RequestHelpers
 
-def get_json(path, params = {}, headers = {})
-  json_request :get, path, params, headers
-end
-
-def post_json(path, params = {}, headers = {})
-  json_request :post, path, params, headers
-end
-
-def put_json(path, params = {}, headers = {})
-  json_request :put, path, params, headers
-end
-
-def delete_json(path, params = {}, headers = {})
-  json_request :delete, path, params, headers
-end
-
-def json_request(verb, path, params = {}, headers = {})
-  send verb, path, params.to_json,
-    headers.merge({ "CONTENT_TYPE" => "application/json" })
-end
 
 def app
   Rubywarden::App

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,0 +1,41 @@
+module Rubywarden
+  module Test
+    class Factory
+      USER_EMAIL = "user@example.com"
+      USER_PASSWORD = "p4ssw0rd"
+
+      def self.create_user email: USER_EMAIL, password: USER_PASSWORD
+        u = User.new
+        u.email = email
+        u.kdf_type = Bitwarden::KDF::TYPE_IDS[User::DEFAULT_KDF_TYPE]
+        u.kdf_iterations = Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]
+        u.password_hash = Bitwarden.hashPassword(password, email,
+          Bitwarden::KDF::TYPES[u.kdf_type], u.kdf_iterations)
+        u.password_hint = "it's like password but not"
+        u.key = Bitwarden.makeEncKey(Bitwarden.makeKey(password, email,
+          Bitwarden::KDF::TYPES[u.kdf_type], u.kdf_iterations))
+        u.save
+        u
+      end
+
+      def self.login_user email: USER_EMAIL, password: USER_PASSWORD
+        post "/identity/connect/token", {
+          :grant_type => "password",
+          :username => email,
+          :password => Bitwarden.hashPassword(password, email,
+            User::DEFAULT_KDF_TYPE,
+            Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]),
+          :scope => "api offline_access",
+          :client_id => "browser",
+          :deviceType => 3,
+          :deviceIdentifier => SecureRandom.uuid,
+          :deviceName => "firefox",
+          :devicePushToken => ""
+        }
+        last_response.status.must_equal 200
+
+        last_json_response["access_token"]
+      end
+    end
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,30 @@
+module Rubywarden
+  module Test
+    module RequestHelpers
+      def last_json_response
+        JSON.parse(last_response.body)
+      end
+
+      def get_json(path, params = {}, headers = {})
+        json_request :get, path, params, headers
+      end
+
+      def post_json(path, params = {}, headers = {})
+        json_request :post, path, params, headers
+      end
+
+      def put_json(path, params = {}, headers = {})
+        json_request :put, path, params, headers
+      end
+
+      def delete_json(path, params = {}, headers = {})
+        json_request :delete, path, params, headers
+      end
+
+      def json_request(verb, path, params = {}, headers = {})
+        send verb, path, params.to_json,
+          headers.merge({ "CONTENT_TYPE" => "application/json" })
+      end
+    end
+  end
+end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -7,16 +7,7 @@ describe "User" do
   before do
     User.all.delete_all
 
-    u = User.new
-    u.email = USER_EMAIL
-    u.kdf_type = Bitwarden::KDF::TYPE_IDS[User::DEFAULT_KDF_TYPE]
-    u.kdf_iterations = Bitwarden::KDF::DEFAULT_ITERATIONS[User::DEFAULT_KDF_TYPE]
-    u.password_hash = Bitwarden.hashPassword(USER_PASSWORD, USER_EMAIL,
-      Bitwarden::KDF::TYPES[u.kdf_type], u.kdf_iterations)
-    u.password_hint = "it's like password but not"
-    u.key = Bitwarden.makeEncKey(Bitwarden.makeKey(USER_PASSWORD, USER_EMAIL,
-      Bitwarden::KDF::TYPES[u.kdf_type], u.kdf_iterations))
-    u.save
+    u = Rubywarden::Test::Factory.create_user email: USER_EMAIL, password: USER_PASSWORD
   end
 
   it "should compare a user's hash" do


### PR DESCRIPTION
tl/dr:
move request helpers to module and include in spec_helper
add inital stab at "factory" for creating and logging in users

I was just working on the web vault stuff and noticed some repetition in the code. Most tests that check something with the api create a user and log that one in, which is always a long blob of code... and it has to be kept up-to-date whenever the api changes. I think it would be nice to have a factory class that just does this, and that can be called upon in the tests. Right now the factory also does the logging in, and therefore the name is not perfectly fitting, but I haven't come up with a better one so far. I put the code into the ```Rubywarden::Test``` namespace to avoid any possible naming conflicts.

In addition I moved all the request helpers like post_json, etc... to a module ```Rubywarden::Test::RequestHelpers``` which gets included. 

All specs still pass fine. I'm mostly working with rspec, so I hope the style is ok. 

I would be glad about any comments and would be happy to incorporate required changes :-)
