### PR TITLE
Containerize for deployment in Podman/Docker/Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ Automated deployment of Rubywarden is possible with 3rd party support:
 
 - [Ansible playbook](https://github.com/qbit/openbsd-rubywarden) for OpenBSD
 
+#### via container
+The repository also contains a container spec as well as resources to run the container via docker-compose or kubernetes.
+
+##### Building
+To build the image: `cd container && docker build .. -t rubywarden`  
+then push it wherever by tagging it:   
+`docker tag rubywarden quay.io/myuser/rubywarden`   
+then pushing:   
+`docker push quay.io/myuser/rubywarden`  
+
+##### docker-compose
+To build and run the container, just run `cd container && docker-compose up -d`   
+
+docker-compose will handle building the image and running it. 
+The container will be running on localhost:4567 with a volume mount for the production db
+
+##### kubernetes
+Build the image, push it somewhere your cluster can pull from, then update the `container/k8s/deployment.yml` file with your image location. From there you should be able to run `kubectl create -f container/k8s/deployment.yml` to create a deployment on your cluster. 
+
+After that, create the service using the `service.yml` file as an example, and if you have an ingress running there is an example `ingress.yml` as well to run rubywarden behind TLS.
+
 ### Manual Setup
 
 Run `bundle install` at least once.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.4
+WORKDIR /app
+
+COPY Gemfile .
+RUN bundle install 
+
+COPY . .
+EXPOSE 4567
+
+CMD ["./container/entrypoint.sh"]

--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+  rubywarden:
+    build:
+      context: ..
+      dockerfile: container/Dockerfile
+    image: rubywarden:latest
+    container_name: rubywarden
+    ports:
+      - "4567:4567"
+    environment:
+      - RUBYWARDEN_ENV=production
+      - RUBYWARDEN_ALLOW_SIGNUPS=0 # change to 1 on first run to allow a signup
+    volumes:
+      - data:/app/db/production
+      #- ./db/production:/app/db/production # local folder if you don't want to use a volume
+

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+bundle exec rake db:migrate && bundle exec rackup -p 4567 config.ru

--- a/container/k8s/all-in-one.yml
+++ b/container/k8s/all-in-one.yml
@@ -1,0 +1,77 @@
+apiVersion: v1
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: rubywarden
+    name: rubywarden
+  spec:
+    selector:
+      matchLabels:
+        app: rubywarden
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: rubywarden
+      spec:
+        containers:
+        - env:
+          - name: RUBYWARDEN_ENV
+            value: production
+          - name: RUBYWARDEN_ALLOW_SIGNUPS
+            value: "0" # Change to a 1 on first signup
+          image: your.image/user/rubywarden
+          imagePullPolicy: Always
+          name: rubywarden
+          resources: {}
+          volumeMounts:
+          - name: db
+            mountPath: /app/db/production
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        volumes:
+        - name: db
+          hostPath:
+            path: /path/on/host
+            type: Directory
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: rubywarden
+    name: rubywarden
+  spec:
+    ports:
+    - port: 4567
+      protocol: TCP
+      targetPort: 4567
+    selector:
+      app: rubywarden
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: extensions/v1beta1
+  kind: Ingress
+  metadata:
+    annotations:
+      certmanager.k8s.io/cluster-issuer: selfsigning-issuer
+      nginx.ingress.kubernetes.io/rewrite-target: /
+    name: rubywarden
+  spec:
+    rules:
+    - host: rubywarden.my.host
+      http:
+        paths:
+        - backend:
+            serviceName: rubywarden
+            servicePort: 4567
+    tls:
+    - hosts:
+      - rubywarden.my-host
+      secretName: rubywarden-cert
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/container/k8s/deployment.yml
+++ b/container/k8s/deployment.yml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: rubywarden
+  name: rubywarden
+spec:
+  selector:
+    matchLabels:
+      app: rubywarden
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: rubywarden
+    spec:
+      containers:
+      - env:
+        - name: RUBYWARDEN_ENV
+          value: production
+        - name: RUBYWARDEN_ALLOW_SIGNUPS
+          value: "0" # Change to a 1 on first signup
+        image: your.image/user/rubywarden
+        imagePullPolicy: Always
+        name: rubywarden
+        resources: {}
+        volumeMounts:
+        - name: db
+          mountPath: /app/db/production
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      volumes:
+      - name: db
+        hostPath:
+          path: /path/on/host
+          type: Directory
+

--- a/container/k8s/ingress.yml
+++ b/container/k8s/ingress.yml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    certmanager.k8s.io/cluster-issuer: my-issuer
+    nginx.ingress.kubernetes.io/rewrite-target: /
+  name: rubywarden
+spec:
+  rules:
+  - host: rubywarden.my.host
+    http:
+      paths:
+      - backend:
+          serviceName: rubywarden
+          servicePort: 4567
+  tls:
+  - hosts:
+    - rubywarden.my-host
+    secretName: rubywarden-cert

--- a/container/k8s/service.yml
+++ b/container/k8s/service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: rubywarden
+  name: rubywarden
+spec:
+  ports:
+  - port: 4567
+    protocol: TCP
+    targetPort: 4567
+  selector:
+    app: rubywarden
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
This PR containerizes the application for those who like to run containers instead of running applications under different users. It also makes it easier to run since all one would have to do is run the container with a volume. 

\# TODO:
- [x] Dockerfile
- [x] `docker-compose.yml` example
- [x] kubernetes deployment/svc/ingress example
- [x] README.md docs